### PR TITLE
Upgrade Node.js version from v12 to v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,5 +46,5 @@ inputs:
     description: 'Define a passphrase for encrypted private keys'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
## What
Closes https://github.com/Creepios/sftp-action/issues/18

Upgrade Node.js version from v12 to v16

## References

- [GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- [GitHub Actions: All Actions will run on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/)
- [Metadata syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions)